### PR TITLE
Remove gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-models/best.ckpt filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Remove .gitattributes file as it is not needed anymore (Git LFS was not used in the end, because ckpt files are too bug for a free GitHub account)